### PR TITLE
Make ChannelTask public, but hidden in docu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --no-default-features --features "serde,codec-postcard" -- -D warnings
-      - run: cargo clippy --no-default-features --features "serde,codec-pot" -- -D warnings
+      - run: cargo clippy --all-features -- -D warnings
 
   doc-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-features -- -D warnings
+      - run: cargo clippy --no-default-features --features "serde,codec-postcard" -- -D warnings
+      - run: cargo clippy --no-default-features --features "serde,codec-pot" -- -D warnings
 
   doc-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["--all-features", "--no-default-features --features serde,codec-pot"]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,17 +25,20 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-features -- -D warnings
+      - run: cargo clippy ${{ matrix.features }} -- -D warnings
 
   doc-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["--all-features", "--no-default-features --features serde,macros,codec-pot"]
 
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run doctest
-        run: cargo test --doc --all-features
+        run: cargo test --doc ${{ matrix.features }}
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +165,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +263,17 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "heapless",
+ "serde",
+]
+
+[[package]]
+name = "pot"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf741fa415952eb20f27fbc210dc85f31cc7cdc80aa3ce81d5e27d28a6f45dc2"
+dependencies = [
+ "byteorder",
+ "half",
  "serde",
 ]
 
@@ -530,6 +558,7 @@ dependencies = [
  "js-sys",
  "log",
  "postcard",
+ "pot",
  "send_wrapper",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.4", features = ["sync"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 log = "0.4"
-postcard = { version = "1.1", features = ["alloc"], optional = true }
+postcard = { version = "1.1", features = ["alloc"] }
 pot = { version = "3.0.1", optional = true }
 
 [dependencies.web-sys]
@@ -64,9 +64,8 @@ version = "0.3"
 wasmworker-proc-macro = { workspace = true }
 
 [features]
-default = ["serde", "codec-postcard"]
+default = ["serde"]
 serde = []
-codec-postcard = ["dep:postcard"]
 codec-pot = ["dep:pot"]
 macros = ["wasmworker-proc-macro"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.4", features = ["sync"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 log = "0.4"
-postcard = { version = "1.1", features = ["alloc"] }
+postcard = { version = "1.1", features = ["alloc"], optional = true }
 pot = { version = "3.0.1", optional = true }
 
 [dependencies.web-sys]
@@ -64,8 +64,9 @@ version = "0.3"
 wasmworker-proc-macro = { workspace = true }
 
 [features]
-default = ["serde"]
+default = ["serde", "codec-postcard"]
 serde = []
+codec-postcard = ["dep:postcard"]
 codec-pot = ["dep:pot"]
 macros = ["wasmworker-proc-macro"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ keywords.workspace = true
 [dependencies]
 futures = "0.3"
 js-sys = { version = "0.3" }
-postcard = { version = "1.1", features = ["alloc"] }
 send_wrapper = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
@@ -40,6 +39,8 @@ tokio = { version = "1.4", features = ["sync"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 log = "0.4"
+postcard = { version = "1.1", features = ["alloc"], optional = true }
+pot = { version = "3.0.1", optional = true }
 
 [dependencies.web-sys]
 features = [
@@ -63,8 +64,10 @@ version = "0.3"
 wasmworker-proc-macro = { workspace = true }
 
 [features]
-default = ["serde"]
+default = ["serde", "codec-postcard"]
 serde = []
+codec-postcard = ["dep:postcard"]
+codec-pot = ["dep:pot"]
 macros = ["wasmworker-proc-macro"]
 
 [dependencies.wasmworker-proc-macro]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In contrast to many other libraries like [wasm-bindgen-rayon](https://github.com
 
 - [Usage](#usage)
   - [Setting up](#setting-up)
+    - [Serialization codec](#serialization-codec)
   - [Outsourcing tasks](#outsourcing-tasks)
     - [WebWorker](#webworker)
     - [WebWorkerPool](#webworkerpool)
@@ -37,6 +38,18 @@ The `wasmworker` crate comes with a default feature called `serde`, which allows
 
 Without the `serde` feature, only functions with the type `fn(Box<[u8]>) -> Box<[u8]>` can be run on a worker.
 This is useful for users that do not want a direct serde dependency. Internally, the library always uses serde, though.
+
+#### Serialization codec
+By default, `wasmworker` uses [postcard](https://crates.io/crates/postcard) for internal serialization.
+Postcard is compact and fast, making it ideal for the typical WebWorker use case (passing `Vec<T>`, structs, primitives).
+
+For complex types like `Rc<T>` or cyclic structures, you can use [pot](https://crates.io/crates/pot) instead.
+Note that pot has significantly higher serialization overhead and larger output sizes, so it should only be used when postcard cannot handle your data types.
+
+```toml
+[dependencies]
+wasmworker = { version = "0.3", default-features = false, features = ["serde", "macros", "codec-pot"] }
+```
 
 You can then start using the library without further setup.
 If you plan on using the global `WebWorkerPool` (using the iterator extensions or `worker_pool()`), you can *optionally* configure this pool:

--- a/src/channel_task.rs
+++ b/src/channel_task.rs
@@ -34,7 +34,8 @@ pub struct ChannelTask<R> {
 
 impl<R: DeserializeOwned> ChannelTask<R> {
     /// Create a new `ChannelTask` from a channel and a result receiver.
-    pub(crate) fn new(channel: Channel, result_rx: oneshot::Receiver<Vec<u8>>) -> Self {
+    #[doc(hidden)]
+    pub fn new(channel: Channel, result_rx: oneshot::Receiver<Vec<u8>>) -> Self {
         Self {
             channel,
             result_rx,

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -41,3 +41,10 @@ pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
         .deserialize(bytes)
         .expect("WebWorker deserialization failed")
 }
+
+// Enforce exactly one:
+#[cfg(all(feature = "codec-postcard", feature = "codec-pot"))]
+compile_error!("Enable only one of: codec-postcard, codec-pot");
+
+#[cfg(not(any(feature = "codec-postcard", feature = "codec-pot")))]
+compile_error!("Enable one of: codec-postcard, codec-pot");

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -19,7 +19,7 @@ pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
 }
 
 #[cfg(feature = "codec-pot")]
-pub const POT_CONFIG: pot::Config = pot::Config::new().compatibility(pot::Compatibility::V4);
+const POT_CONFIG: pot::Config = pot::Config::new().compatibility(pot::Compatibility::V4);
 
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values before sending them to a worker

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values before sending them to a worker
 /// or back to the main thread via `postMessage`.
-#[cfg(feature = "codec-postcard")]
+#[cfg(not(feature = "codec-pot"))]
 pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
     postcard::to_allocvec(value)
         .expect("WebWorker serialization failed")
@@ -13,7 +13,7 @@ pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values after receiving them from a worker
 /// or the main thread via `postMessage`.
-#[cfg(feature = "codec-postcard")]
+#[cfg(not(feature = "codec-pot"))]
 pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
     postcard::from_bytes(bytes).expect("WebWorker deserialization failed")
 }
@@ -41,10 +41,3 @@ pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
         .deserialize(bytes)
         .expect("WebWorker deserialization failed")
 }
-
-// Enforce exactly one:
-#[cfg(all(feature = "codec-postcard", feature = "codec-pot"))]
-compile_error!("Enable only one of: codec-postcard, codec-pot");
-
-#[cfg(not(any(feature = "codec-postcard", feature = "codec-pot")))]
-compile_error!("Enable one of: codec-postcard, codec-pot");

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -27,7 +27,7 @@ pub const POT_CONFIG: pot::Config = pot::Config::new().compatibility(pot::Compat
 #[cfg(feature = "codec-pot")]
 pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
     POT_CONFIG
-        .serialize(self)
+        .serialize(value)
         .expect("WebWorker serialization failed")
         .into()
 }
@@ -39,5 +39,5 @@ pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
 pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
     POT_CONFIG
         .deserialize(bytes)
-        expect("WebWorker deserialization failed")
+        .expect("WebWorker deserialization failed")
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values before sending them to a worker
 /// or back to the main thread via `postMessage`.
-#[cfg(not(feature = "codec-pot"))]
+#[cfg(feature = "codec-postcard")]
 pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
     postcard::to_allocvec(value)
         .expect("WebWorker serialization failed")
@@ -13,18 +13,18 @@ pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values after receiving them from a worker
 /// or the main thread via `postMessage`.
-#[cfg(not(feature = "codec-pot"))]
+#[cfg(feature = "codec-postcard")]
 pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
     postcard::from_bytes(bytes).expect("WebWorker deserialization failed")
 }
 
-#[cfg(feature = "codec-pot")]
+#[cfg(all(feature = "codec-pot", not(feature = "codec-postcard")))]
 const POT_CONFIG: pot::Config = pot::Config::new().compatibility(pot::Compatibility::V4);
 
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values before sending them to a worker
 /// or back to the main thread via `postMessage`.
-#[cfg(feature = "codec-pot")]
+#[cfg(all(feature = "codec-pot", not(feature = "codec-postcard")))]
 pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
     POT_CONFIG
         .serialize(value)
@@ -35,9 +35,12 @@ pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values after receiving them from a worker
 /// or the main thread via `postMessage`.
-#[cfg(feature = "codec-pot")]
+#[cfg(all(feature = "codec-pot", not(feature = "codec-postcard")))]
 pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
     POT_CONFIG
         .deserialize(bytes)
         .expect("WebWorker deserialization failed")
 }
+
+#[cfg(not(any(feature = "codec-postcard", feature = "codec-pot")))]
+compile_error!("No codec selected. Enable `codec-postcard` (default) or `codec-pot`.");

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values before sending them to a worker
 /// or back to the main thread via `postMessage`.
+#[cfg(feature = "codec-postcard")]
 pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
     postcard::to_allocvec(value)
         .expect("WebWorker serialization failed")
@@ -12,6 +13,31 @@ pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
 /// This wrapper function encapsulates our internal serialization format.
 /// It is used internally to prepare values after receiving them from a worker
 /// or the main thread via `postMessage`.
+#[cfg(feature = "codec-postcard")]
 pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
     postcard::from_bytes(bytes).expect("WebWorker deserialization failed")
+}
+
+#[cfg(feature = "codec-pot")]
+pub const POT_CONFIG: pot::Config = pot::Config::new().compatibility(pot::Compatibility::V4);
+
+/// This wrapper function encapsulates our internal serialization format.
+/// It is used internally to prepare values before sending them to a worker
+/// or back to the main thread via `postMessage`.
+#[cfg(feature = "codec-pot")]
+pub fn to_bytes<T: Serialize>(value: &T) -> Box<[u8]> {
+    POT_CONFIG
+        .serialize(self)
+        .expect("WebWorker serialization failed")
+        .into()
+}
+
+/// This wrapper function encapsulates our internal serialization format.
+/// It is used internally to prepare values after receiving them from a worker
+/// or the main thread via `postMessage`.
+#[cfg(feature = "codec-pot")]
+pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> T {
+    POT_CONFIG
+        .deserialize(bytes)
+        expect("WebWorker deserialization failed")
 }


### PR DESCRIPTION
So now I'm a bit late with a response :sweat_smile 
Thank you very much for your rework and the release of the new version. 
My problem with postcard were SerializeSeqLengthUnknown errors, which I have fixed right now.

Right now I need to have the ChannelTask creation available.
The reason is, sometimes I want to execute certain logic in the main thread or WebWorker. In this cases my custom logic needs the channel in the same way as when I work with WebWorker. 
I understand, that this is quiet niche, so I hid the new function from the docs.