### PR TITLE
Bump rand to 0.9 and getrandom to 0.3 in demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,14 +153,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -305,21 +306,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -327,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
@@ -486,10 +492,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -619,6 +628,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -17,9 +17,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 futures = "0.3"
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 js-sys = "0.3"
-rand = "0.8"
+rand = "0.9"
 send_wrapper = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.43", features = ["sync"] }


### PR DESCRIPTION
## Summary
- Bumps `rand` from 0.8 to 0.9 and `getrandom` from 0.2 to 0.3 in the `demo` crate
- `getrandom 0.3` renamed the wasm browser feature from `js` to `wasm_js`; no `getrandom_backend` cfg flag is required (it's a no-op in 0.3)
- No source changes — the demo's three `rand::random()` calls are fully qualified and remain valid in rand 0.9 (only the prelude re-export was removed)

Supersedes #17 (dependabot couldn't migrate `getrandom` alongside `rand`, which is what caused the resolver failure on that PR).

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo +nightly clippy --all-features -- -D warnings`
- [x] `cargo +nightly clippy --no-default-features --features iter-ext,codec-pot -- -D warnings`
- [x] `cargo test --doc --all-features`
- [x] `cargo test --doc --no-default-features --features iter-ext,macros,codec-pot`
- [x] `cargo build --target wasm32-unknown-unknown -p wasmworker-demo`
- [x] `wasm-pack build --target web` for the `test` crate (postcard + pot)
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)